### PR TITLE
Edge Consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # CDT Tools in Python
 
-[![PyPI version](https://img.shields.io/pypi/v/cdtea)](https://pypi.org/project/collapse/)
-[![PyPI downloads](https://img.shields.io/pypi/dm/cdtea)](https://pypi.org/project/collapse/)
-[![PyPI versions](https://img.shields.io/pypi/pyversions/cdtea)](https://pypi.org/project/collapse/)
-[![Build](https://img.shields.io/travis/jacksonhenry3/CDT)](https://pypi.org/project/collapse/)
+[![PyPI version](https://img.shields.io/pypi/v/cdtea)](https://pypi.org/project/cdtea/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/cdtea)](https://pypi.org/project/cdtea/)
+[![PyPI versions](https://img.shields.io/pypi/pyversions/cdtea)](https://pypi.org/project/cdtea/)
+[![Build](https://img.shields.io/travis/com/jacksonhenry3/CDT)](https://pypi.org/project/cdtea/)
 [![codecov](https://codecov.io/gh/jacksonhenry3/CDT/branch/main/graph/badge.svg?token=G418VYV5LR)](undefined)
 [![CodeFactor Quality](https://img.shields.io/codefactor/grade/github/jacksonhenry3/CDT?&label=codefactor)](https://pypi.org/project/cdtea/)
 [![License](https://img.shields.io/github/license/jacksonhenry3/CDT?color=magenta&label=License)](https://pypi.org/project/cdtea/)
@@ -11,6 +11,7 @@
 The `cdtea` package contains utilities for computing CDT in 1+1 dimensions. Architecture is currently in flux, this
 README will update when package has stabilized, see the [issues](https://github.com/jacksonhenry3/CDT/issues) page for
 planned features.
+
 
 
 

--- a/cdtea/event.py
+++ b/cdtea/event.py
@@ -25,7 +25,15 @@ class Event:
     SpaceTime object.
     """
 
-    def __init__(self, space_time, event_key, ):
+    def __init__(self, space_time, event_key):
+        """Create an Event isntance
+
+        Args:
+            space_time:
+                SpaceTime, the spacetime object
+            event_key:
+                int, the Event label
+        """
         self.space_time = space_time
         if isinstance(event_key, Event):
             # TODO check space_time equivalence
@@ -36,6 +44,15 @@ class Event:
         self.key = event_key
 
     def __eq__(self, other):
+        """Equality comparison operator
+
+        Args:
+            other:
+                Any, if an Event instance compare for equality
+
+        Returns:
+            bool, True if equivalent events, False otherwise
+        """
         # TODO add "and other.space_time == self.space_time" once __eq__ defined for SpaceTime
         return isinstance(other, Event) and other.key == self.key
 
@@ -61,7 +78,7 @@ class Event:
         """Make Event hashable
 
         Returns:
-
+            int, the has value of the Event
         """
         # TODO add spacetime hash
         return hash(('Event', self.key))
@@ -91,18 +108,38 @@ class Event:
 
     @property
     def spatial_neighbors(self):
+        """Spatial Neighbors are those that are connected to this event via space-like edges
+
+        Returns:
+            List[Event], the left and right neighbors
+        """
         return [self.left, self.right]
 
     @property
     def temporal_neighbors(self):
+        """Temporal neighbors are those that are connected to this event via time-like edges
+
+        Returns:
+            List[Event], the past and future neighbors
+        """
         return self.past + self.future
 
     @property
     def neighbors(self):
+        """All neighbors, events connected to this event via any kind of edge
+
+        Returns:
+            List[Event], all neighbor events
+        """
         return self.spatial_neighbors + self.temporal_neighbors
 
     @property
     def is_gluing_point(self):
+        """Boolean variable for determining gluing points
+
+        Returns:
+            bool, True if this event represents a gluing point, False otherwise.
+        """
         return isinstance(self.key, GluingPoint)
 
 
@@ -139,16 +176,34 @@ def events(space_time, keys: typing.Union[int, typing.Iterable[int]]) -> typing.
     return Event(space_time=space_time, event_key=keys)
 
 
-# Some sketch of gluing tools
-
 class GluingPoint(int):
-    pass
+    """A Gluing Point represents a reference to an "open edge" or an event that
+    does not belong to a particular spacetime. They are used for gluing spacetimes
+    together, which primarily arises as a functional inverse to removing a subset of
+    events from a spacetime (or 'cutting'). The terminology of cutting / gluing is
+    borrowed from topological literature.
+
+    The Gluing Point int subclass is used to passively identify gluing points
+    as event keys without changing and fundamental behavior of the event key.
+    """
 
 
 def coerce_gluing_point(space_time, event: typing.Union[Event, typing.Iterable[Event]]):
+    """Coerce event key to GluingPoints if the event does not belong to the space_time
+
+    Args:
+        space_time:
+            SpaceTime, the spacetime object
+        event:
+            Event, the event to coerce. key will be wrapped as GluingPoint if event
+            does not belong the space_time argument
+
+    Returns:
+        Event or List[Event], the coerced events
+    """
     # Naive
     if isinstance(event, Iterable):
         return [coerce_gluing_point(space_time, v) for v in event]
     if event.key not in space_time.nodes:
-        return Event(space_time, event_key=GluingPoint(event.key))
+        return Event(event.space_time, event_key=GluingPoint(event.key))
     return event

--- a/cdtea/event.py
+++ b/cdtea/event.py
@@ -71,9 +71,24 @@ class Event:
             bool, True if equivalent events, False otherwise
         """
         # TODO add "and other.space_time == self.space_time" once __eq__ defined for SpaceTime
-        return isinstance(other, Event) and other.key == self.key
+        return isinstance(other, Event) and (other.space_time == self.space_time) and (other.key == self.key)
 
-    def _get_pass_thru_attr_(self, key):
+    def __hash__(self):
+        """Make Event hashable
+
+        Returns:
+            int, the has value of the Event
+        """
+        # TODO add spacetime hash
+        return hash(('Event', self.key))
+
+    def __repr__(self):
+        """Define convenient representation for events"""
+        # TODO update this to use the SpaceTime repr, now it's just using STN
+        # TODO update this to include a time coordinate if possible
+        return 'Event(ST{:d}, {:d})'.format(len(self.space_time.nodes), -1 if self.key is None else self.key)
+
+    def _get_pass_thru_attr_(self, key: str):
         """Helper private method for looking up pass-thru attributes.For these attributes only,
         the call will be redirected to the underlying SpaceTime object from which the key originates
 
@@ -93,20 +108,32 @@ class Event:
                 return value if value is None else Event(space_time=self.space_time, event_key=value)
             return value
 
-    def __hash__(self):
-        """Make Event hashable
+    @property
+    def faces(self):
+        """Pass-thru accessor for faces
 
         Returns:
-            int, the has value of the Event
+            List[frozenset], the faces
         """
-        # TODO add spacetime hash
-        return hash(('Event', self.key))
+        return self._get_pass_thru_attr_(PassThruAttr.Faces)
 
-    def __repr__(self):
-        """Define convenient representation for events"""
-        # TODO update this to use the SpaceTime repr, now it's just using STN
-        # TODO update this to include a time coordinate if possible
-        return 'Event(ST{:d}, {:d})'.format(len(self.space_time.nodes), -1 if self.key is None else self.key)
+    @property
+    def future(self):
+        """Pass-thru accessor for future neighbors
+
+        Returns:
+            List[Event], the future neighbors
+        """
+        return self._get_pass_thru_attr_(PassThruAttr.Future)
+
+    @property
+    def is_gluing_point(self):
+        """Boolean variable for determining gluing points
+
+        Returns:
+            bool, True if this event represents a gluing point, False otherwise.
+        """
+        return isinstance(self.key, GluingPoint)
 
     @property
     def left(self):
@@ -118,13 +145,13 @@ class Event:
         return self._get_pass_thru_attr_(PassThruAttr.Left)
 
     @property
-    def right(self):
-        """Pass-thru accessor for right neighbor
+    def neighbors(self):
+        """All neighbors, events connected to this event via any kind of edge
 
         Returns:
-            Event, the right neighbor
+            List[Event], all neighbor events
         """
-        return self._get_pass_thru_attr_(PassThruAttr.Right)
+        return self.spatial_neighbors + self.temporal_neighbors
 
     @property
     def past(self):
@@ -136,13 +163,13 @@ class Event:
         return self._get_pass_thru_attr_(PassThruAttr.Past)
 
     @property
-    def future(self):
-        """Pass-thru accessor for future neighbors
+    def right(self):
+        """Pass-thru accessor for right neighbor
 
         Returns:
-            List[Event], the future neighbors
+            Event, the right neighbor
         """
-        return self._get_pass_thru_attr_(PassThruAttr.Future)
+        return self._get_pass_thru_attr_(PassThruAttr.Right)
 
     @property
     def spatial_neighbors(self):
@@ -161,24 +188,6 @@ class Event:
             List[Event], the past and future neighbors
         """
         return self.past + self.future
-
-    @property
-    def neighbors(self):
-        """All neighbors, events connected to this event via any kind of edge
-
-        Returns:
-            List[Event], all neighbor events
-        """
-        return self.spatial_neighbors + self.temporal_neighbors
-
-    @property
-    def is_gluing_point(self):
-        """Boolean variable for determining gluing points
-
-        Returns:
-            bool, True if this event represents a gluing point, False otherwise.
-        """
-        return isinstance(self.key, GluingPoint)
 
 
 def event_key(e: typing.Union[Event, int]) -> int:
@@ -216,72 +225,6 @@ def events(space_time, keys: typing.Union[int, typing.Iterable[int]] = None) -> 
     return Event(space_time=space_time, event_key=keys)
 
 
-def connect(self, key, value):
-    """Override the behavior of attribute setting ONLY for the case of pass-thru attributes,
-    which are defined above in PASS_THRU_ATTRIBUTES. for these attributes only, the setattr
-    call will be redirected to the underlying SpaceTime object from which the key originates
-
-    Args:
-        key:
-            str, the name of the attribute to set
-        value:
-            Any, if an Event instance and key is a pass-thru attr, value will be coerced to int before
-            assignment to corresponding SpaceTime attribute lookup dict
-
-    Notes:
-        Edge Consistency:
-            The below code ensures that both ends of edges are maintained in a way that
-            preserves the following consistency relations between events A and B:
-
-                (1) A.right = B    <==>  A = B.left
-                (2) A.left = B     <==>  A = B.right
-                (3) B in A.past    <==>  A in B.future
-                (4) B in A.future  <==>  A in B.past
-
-            In order to maintain relations (3) and (4), the original value of the attribute
-            assigned to the given key must be tracked, so as to know which event to update
-            after the new attribute assignment.
-    """
-    if key not in PASS_THRU_ATTR_MAP:
-        return super().__setattr__(key, value)
-
-    # Assign new value
-    value_key = [event_key(v) for v in value] if isinstance(value, Iterable) else event_key(value)
-    original_value = getattr(self, key)
-    getattr(self.space_time, PASS_THRU_ATTR_MAP[key])[self.key] = value_key
-
-    if original_value is None or original_value == []:
-        # Short-circuit if the original value is None (this corresponds to a empty-reference)
-        return
-
-    if key not in EDGE_CONSISTENCY_ATTR_DUALS:
-        # TODO define behavior for faces and face consistency
-        return
-
-    # Curate remaining values for edge-consistency
-    if isinstance(value, Iterable):
-        # Update the edge-consistency dual-attribute of the newly assigned event
-        new_events = [n for n in value if n not in original_value]
-        for n in new_events:
-            if self.key not in getattr(n.space_time, PASS_THRU_ATTR_MAP[EDGE_CONSISTENCY_ATTR_DUALS[key]])[n.key]:
-                getattr(n.space_time, PASS_THRU_ATTR_MAP[EDGE_CONSISTENCY_ATTR_DUALS[key]])[n.key].append(self.key)
-
-        # Update the edge-consistency dual-attribute of the replaced event
-        # TODO must decide about replaced edge behavior
-        # replaced_events = [n for n in original_value if n not in value]
-        # for r in replaced_events:
-        #     if self.key in getattr(r.space_time, PASS_THRU_ATTRS[EDGE_CONSISTENCY_ATTR_DUALS[key]])[r.key]:
-        #         getattr(r.space_time, PASS_THRU_ATTRS[EDGE_CONSISTENCY_ATTR_DUALS[key]])[r.key].remove(self.key)
-    else:
-        # Update the edge-consistency dual-attribute of the newly assigned event
-        if getattr(value, EDGE_CONSISTENCY_ATTR_DUALS[key]) != self:
-            setattr(value, EDGE_CONSISTENCY_ATTR_DUALS[key], self)
-
-        # Update the edge-consistency dual-attribute of the replaced event
-        # TODO we need to think about this behavior, the replaced event has no natural replaced attribute?
-        # getattr(original_value.space_time, PASS_THRU_ATTRS[EDGE_CONSISTENCY_ATTR_DUALS[key]])[original_value.key] = None
-
-
 class GluingPoint(int):
     """A Gluing Point represents a reference to an "open edge" or an event that
     does not belong to a particular spacetime. They are used for gluing spacetimes
@@ -313,3 +256,89 @@ def coerce_gluing_point(space_time, event: typing.Union[Event, typing.Iterable[E
     if event.key not in space_time.nodes:
         return Event(event.space_time, event_key=GluingPoint(event.key))
     return event
+
+
+def connect_spatial(left: Event, right: Event):
+    """Make a consistent spatial connection between two events
+
+    Args:
+        left:
+            Event, the event to be on the left side of the spatial connection
+        left:
+            Event, the event to be on the right side of the spatial connection
+
+    Notes:
+        Edge Consistency:
+            The below code ensures that both ends of edges are maintained in a way that
+            preserves the following consistency relations between events A and B:
+
+                (1) A.right = B    <==>  A = B.left
+                (2) A.left = B     <==>  A = B.right
+    """
+    # Set left.right = right
+    if not left.is_gluing_point and left.right != right:
+        original_right_of_left = left.right
+        getattr(left.space_time, PASS_THRU_ATTR_MAP[PassThruAttr.Right])[left.key] = coerce_gluing_point(left.space_time, right).key
+        if original_right_of_left is not None:
+            getattr(original_right_of_left.space_time, PASS_THRU_ATTR_MAP[PassThruAttr.Left])[original_right_of_left.key] = None
+
+    # Set right.left = left
+    if not right.is_gluing_point and right.left != left:
+        original_left_of_right = right.left
+        getattr(right.space_time, PASS_THRU_ATTR_MAP[PassThruAttr.Left])[right.key] = coerce_gluing_point(right.space_time, left).key
+        if original_left_of_right is not None:
+            getattr(original_left_of_right.space_time, PASS_THRU_ATTR_MAP[PassThruAttr.Right])[original_left_of_right.key] = None
+
+
+def connect_temporal(present: Event, past: typing.List[Event] = None, future: typing.List[Event] = None):
+    """Make a consistent connection between a present event and a collection of past or future events
+
+    Args:
+        present:
+            Event, the event for which to update the past or future
+        past:
+            List[Event], default None, if specified, set the past of present equal to these events
+        future:
+            List[Event], default None, if specified, set the future of present equal to these events
+
+    Notes:
+        Edge Consistency:
+            The below code ensures that both ends of edges are maintained in a way that
+            preserves the following consistency relations between events A and B:
+
+                (3) B in A.past    <==>  A in B.future
+                (4) B in A.future  <==>  A in B.past
+    """
+    if past is None and future is None:
+        raise ValueError('Must specify either past or future of present event')
+
+    for attr, value in zip((PassThruAttr.Past, PassThruAttr.Future), (past, future)):
+        dual_attr = EDGE_CONSISTENCY_ATTR_DUALS_DICT[attr]
+        if value is not None:
+            # Set new value and keep track of original
+            original = getattr(present, attr)
+            getattr(present.space_time, PASS_THRU_ATTR_MAP[attr])[present.key] = [v.key for v in coerce_gluing_point(present.space_time, value)]
+
+            # Set consistency condition for new nodes
+            new = [e for e in value if e not in original]
+            for n in new:
+                if not n.is_gluing_point and present not in getattr(n, dual_attr):
+                    getattr(n.space_time, PASS_THRU_ATTR_MAP[dual_attr])[n.key].append(coerce_gluing_point(n.space_time, present).key)
+
+            # Set consistency condition for replaced nodes
+            replaced = [e for e in original if e not in value]
+            for r in replaced:
+                if not r.is_gluing_point and present in getattr(r, dual_attr):
+                    getattr(r.space_time, PASS_THRU_ATTR_MAP[dual_attr])[r.key].remove(coerce_gluing_point(r.space_time, present).key)
+
+
+def set_faces(event: Event, faces: typing.List[frozenset]):
+    """Utility for setting the faces attribute of an event
+
+    Args:
+        event:
+            Event, the event for which to update the faces
+        faces:
+            List[frozenset], the faces to assign to the event
+    """
+    getattr(event.space_time, PASS_THRU_ATTR_MAP[PassThruAttr.Faces])[event.key] = faces

--- a/cdtea/event.py
+++ b/cdtea/event.py
@@ -6,24 +6,33 @@ sugar for code readability
 import typing
 from collections import Iterable
 
-PASS_THRU_ATTRS = {
+
+class PassThruAttr:
+    """Constants class for pass thru attributes"""
+    Left = 'left'
+    Right = 'right'
+    Past = 'past'
+    Future = 'future'
+    Faces = 'faces'
+
+
+PASS_THRU_ATTR_MAP = {
     # Mapping of attribute name in Node object and corresponding lookup-dict in SpaceTime object
     # NOTE: this depends on implementation details of SpaceTime class, and should be updated in tandem
-    'left': 'node_left',
-    'right': 'node_right',
-    'past': 'node_past',
-    'future': 'node_future',
-    'faces': 'faces_containing'
+    PassThruAttr.Left: 'node_left',
+    PassThruAttr.Right: 'node_right',
+    PassThruAttr.Past: 'node_past',
+    PassThruAttr.Future: 'node_future',
+    PassThruAttr.Faces: 'faces_containing'
 }
 EVENT_RETURNING_ATTRS = ('left', 'right', 'past', 'future')
-EDGE_CONSISTENCY_ATTR_DUALS = {
+EDGE_CONSISTENCY_ATTR_DUALS = [
     # Mapping of attributes that define edge consistency relationships, which
     # may also be viewed as parity and time-reversal duals
-    'left': 'right',
-    'right': 'left',
-    'past': 'future',
-    'future': 'past',
-}
+    (PassThruAttr.Left, PassThruAttr.Right),
+    (PassThruAttr.Past, PassThruAttr.Future),
+]
+EDGE_CONSISTENCY_ATTR_DUALS_DICT = dict(EDGE_CONSISTENCY_ATTR_DUALS + [(v, k) for k, v in EDGE_CONSISTENCY_ATTR_DUALS])
 
 
 class Event:
@@ -34,7 +43,7 @@ class Event:
     """
 
     def __init__(self, space_time, event_key):
-        """Create an Event isntance
+        """Create an Event instance
 
         Args:
             space_time:
@@ -64,23 +73,25 @@ class Event:
         # TODO add "and other.space_time == self.space_time" once __eq__ defined for SpaceTime
         return isinstance(other, Event) and other.key == self.key
 
-    def __getattr__(self, item):
-        """Override the behavior of attribute lookup ONLY for the case of pass-thru attributes,
-        which are defined above in PASS_THRU_ATTRIBUTES. for these attributes only, the getattr
-        call will be redirected to the underlying SpaceTime object from which the key originates
+    def _get_pass_thru_attr_(self, key):
+        """Helper private method for looking up pass-thru attributes.For these attributes only,
+        the call will be redirected to the underlying SpaceTime object from which the key originates
 
         Args:
-            item:
+            key:
                 str, the name of the attribute to get
+
+        Returns:
+            Event, List[Event], or List[frozenset] depending on whether a single neighbor,
+            multiple neighbors, or faces are requested
         """
-        if item in PASS_THRU_ATTRS:
-            value = getattr(self.space_time, PASS_THRU_ATTRS[item])[self.key]
-            if item in EVENT_RETURNING_ATTRS:
+        if key in PASS_THRU_ATTR_MAP:
+            value = getattr(self.space_time, PASS_THRU_ATTR_MAP[key])[self.key]
+            if key in EVENT_RETURNING_ATTRS:
                 if isinstance(value, Iterable):
                     return [v if v is None else Event(space_time=self.space_time, event_key=v) for v in value]
                 return value if value is None else Event(space_time=self.space_time, event_key=value)
             return value
-        return super(Event, self).__getattribute__(item)
 
     def __hash__(self):
         """Make Event hashable
@@ -97,70 +108,41 @@ class Event:
         # TODO update this to include a time coordinate if possible
         return 'Event(ST{:d}, {:d})'.format(len(self.space_time.nodes), -1 if self.key is None else self.key)
 
-    def __setattr__(self, key, value):
-        """Override the behavior of attribute setting ONLY for the case of pass-thru attributes,
-        which are defined above in PASS_THRU_ATTRIBUTES. for these attributes only, the setattr
-        call will be redirected to the underlying SpaceTime object from which the key originates
+    @property
+    def left(self):
+        """Pass-thru accessor for left neighbor
 
-        Args:
-            key:
-                str, the name of the attribute to set
-            value:
-                Any, if an Event instance and key is a pass-thru attr, value will be coerced to int before
-                assignment to corresponding SpaceTime attribute lookup dict
-
-        Notes:
-            Edge Consistency:
-                The below code ensures that both ends of edges are maintained in a way that
-                preserves the following consistency relations between events A and B:
-
-                    (1) A.right = B    <==>  A = B.left
-                    (2) A.left = B     <==>  A = B.right
-                    (3) B in A.past    <==>  A in B.future
-                    (4) B in A.future  <==>  A in B.past
-
-                In order to maintain relations (3) and (4), the original value of the attribute
-                assigned to the given key must be tracked, so as to know which event to update
-                after the new attribute assignment.
+        Returns:
+            Event, the left neighbor
         """
-        if key not in PASS_THRU_ATTRS:
-            return super().__setattr__(key, value)
+        return self._get_pass_thru_attr_(PassThruAttr.Left)
 
-        # Assign new value
-        value_key = [event_key(v) for v in value] if isinstance(value, Iterable) else event_key(value)
-        original_value = getattr(self, key)
-        getattr(self.space_time, PASS_THRU_ATTRS[key])[self.key] = value_key
+    @property
+    def right(self):
+        """Pass-thru accessor for right neighbor
 
-        if original_value is None or original_value == []:
-            # Short-circuit if the original value is None (this corresponds to a empty-reference)
-            return
+        Returns:
+            Event, the right neighbor
+        """
+        return self._get_pass_thru_attr_(PassThruAttr.Right)
 
-        if key not in EDGE_CONSISTENCY_ATTR_DUALS:
-            # TODO define behavior for faces and face consistency
-            return
+    @property
+    def past(self):
+        """Pass-thru accessor for past neighbors
 
-        # Curate remaining values for edge-consistency
-        if isinstance(value, Iterable):
-            # Update the edge-consistency dual-attribute of the newly assigned event
-            new_events = [n for n in value if n not in original_value]
-            for n in new_events:
-                if self.key not in getattr(n.space_time, PASS_THRU_ATTRS[EDGE_CONSISTENCY_ATTR_DUALS[key]])[n.key]:
-                    getattr(n.space_time, PASS_THRU_ATTRS[EDGE_CONSISTENCY_ATTR_DUALS[key]])[n.key].append(self.key)
+        Returns:
+            List[Event], the past neighbors
+        """
+        return self._get_pass_thru_attr_(PassThruAttr.Past)
 
-            # Update the edge-consistency dual-attribute of the replaced event
-            # TODO must decide about replaced edge behavior
-            # replaced_events = [n for n in original_value if n not in value]
-            # for r in replaced_events:
-            #     if self.key in getattr(r.space_time, PASS_THRU_ATTRS[EDGE_CONSISTENCY_ATTR_DUALS[key]])[r.key]:
-            #         getattr(r.space_time, PASS_THRU_ATTRS[EDGE_CONSISTENCY_ATTR_DUALS[key]])[r.key].remove(self.key)
-        else:
-            # Update the edge-consistency dual-attribute of the newly assigned event
-            if getattr(value, EDGE_CONSISTENCY_ATTR_DUALS[key]) != self:
-                setattr(value, EDGE_CONSISTENCY_ATTR_DUALS[key], self)
+    @property
+    def future(self):
+        """Pass-thru accessor for future neighbors
 
-            # Update the edge-consistency dual-attribute of the replaced event
-            # TODO we need to think about this behavior, the replaced event has no natural replaced attribute?
-            # getattr(original_value.space_time, PASS_THRU_ATTRS[EDGE_CONSISTENCY_ATTR_DUALS[key]])[original_value.key] = None
+        Returns:
+            List[Event], the future neighbors
+        """
+        return self._get_pass_thru_attr_(PassThruAttr.Future)
 
     @property
     def spatial_neighbors(self):
@@ -212,7 +194,7 @@ def event_key(e: typing.Union[Event, int]) -> int:
     return e.key if isinstance(e, Event) else e
 
 
-def events(space_time, keys: typing.Union[int, typing.Iterable[int]]) -> typing.Union[Event, typing.List[Event]]:
+def events(space_time, keys: typing.Union[int, typing.Iterable[int]] = None) -> typing.Union[Event, typing.List[Event]]:
     """Helper function for creating multiple Event instances from an iterable
     of SpaceTime keys
 
@@ -227,9 +209,77 @@ def events(space_time, keys: typing.Union[int, typing.Iterable[int]]) -> typing.
     """
     if isinstance(space_time, Iterable):  # TODO more thorough check in case we make spacetime iterable..
         return list(zip(*[events(st, keys) for st in space_time]))
+    if keys is None:
+        keys = space_time.nodes
     if isinstance(keys, Iterable):
         return [Event(space_time=space_time, event_key=k) for k in keys]
     return Event(space_time=space_time, event_key=keys)
+
+
+def connect(self, key, value):
+    """Override the behavior of attribute setting ONLY for the case of pass-thru attributes,
+    which are defined above in PASS_THRU_ATTRIBUTES. for these attributes only, the setattr
+    call will be redirected to the underlying SpaceTime object from which the key originates
+
+    Args:
+        key:
+            str, the name of the attribute to set
+        value:
+            Any, if an Event instance and key is a pass-thru attr, value will be coerced to int before
+            assignment to corresponding SpaceTime attribute lookup dict
+
+    Notes:
+        Edge Consistency:
+            The below code ensures that both ends of edges are maintained in a way that
+            preserves the following consistency relations between events A and B:
+
+                (1) A.right = B    <==>  A = B.left
+                (2) A.left = B     <==>  A = B.right
+                (3) B in A.past    <==>  A in B.future
+                (4) B in A.future  <==>  A in B.past
+
+            In order to maintain relations (3) and (4), the original value of the attribute
+            assigned to the given key must be tracked, so as to know which event to update
+            after the new attribute assignment.
+    """
+    if key not in PASS_THRU_ATTR_MAP:
+        return super().__setattr__(key, value)
+
+    # Assign new value
+    value_key = [event_key(v) for v in value] if isinstance(value, Iterable) else event_key(value)
+    original_value = getattr(self, key)
+    getattr(self.space_time, PASS_THRU_ATTR_MAP[key])[self.key] = value_key
+
+    if original_value is None or original_value == []:
+        # Short-circuit if the original value is None (this corresponds to a empty-reference)
+        return
+
+    if key not in EDGE_CONSISTENCY_ATTR_DUALS:
+        # TODO define behavior for faces and face consistency
+        return
+
+    # Curate remaining values for edge-consistency
+    if isinstance(value, Iterable):
+        # Update the edge-consistency dual-attribute of the newly assigned event
+        new_events = [n for n in value if n not in original_value]
+        for n in new_events:
+            if self.key not in getattr(n.space_time, PASS_THRU_ATTR_MAP[EDGE_CONSISTENCY_ATTR_DUALS[key]])[n.key]:
+                getattr(n.space_time, PASS_THRU_ATTR_MAP[EDGE_CONSISTENCY_ATTR_DUALS[key]])[n.key].append(self.key)
+
+        # Update the edge-consistency dual-attribute of the replaced event
+        # TODO must decide about replaced edge behavior
+        # replaced_events = [n for n in original_value if n not in value]
+        # for r in replaced_events:
+        #     if self.key in getattr(r.space_time, PASS_THRU_ATTRS[EDGE_CONSISTENCY_ATTR_DUALS[key]])[r.key]:
+        #         getattr(r.space_time, PASS_THRU_ATTRS[EDGE_CONSISTENCY_ATTR_DUALS[key]])[r.key].remove(self.key)
+    else:
+        # Update the edge-consistency dual-attribute of the newly assigned event
+        if getattr(value, EDGE_CONSISTENCY_ATTR_DUALS[key]) != self:
+            setattr(value, EDGE_CONSISTENCY_ATTR_DUALS[key], self)
+
+        # Update the edge-consistency dual-attribute of the replaced event
+        # TODO we need to think about this behavior, the replaced event has no natural replaced attribute?
+        # getattr(original_value.space_time, PASS_THRU_ATTRS[EDGE_CONSISTENCY_ATTR_DUALS[key]])[original_value.key] = None
 
 
 class GluingPoint(int):

--- a/cdtea/space_time.py
+++ b/cdtea/space_time.py
@@ -39,6 +39,13 @@ class SpaceTime(object):
         # https://stackoverflow.com/questions/28176866/find-the-smallest-positive-number-not-in-list
         # self.max_node = 0
 
+    def __eq__(self, other):
+        """Equivalence between """
+        if not isinstance(other, SpaceTime):
+            return False
+        # TODO add checking of edges and faces
+        return self.nodes == other.nodes
+
     @property
     def max_node(self):
         return max(self.nodes)
@@ -163,7 +170,7 @@ class SpaceTime(object):
         """
         This creates a new space-time by removing all nodes adjacent to node and returning that sub_space
         """
-        sub_space = SpaceTime(closed=False) # the sub_space will contain references to nodes that do not belong to it (for gluing purposes)
+        sub_space = SpaceTime(closed=False)  # the sub_space will contain references to nodes that do not belong to it (for gluing purposes)
 
         nodes = node_list.copy()
         faces = []
@@ -184,11 +191,11 @@ class SpaceTime(object):
         # taking care to label gluing points (references to nodes that do not belong to sub_space)
         coerce = lambda keys: event.coerce_gluing_point(sub_space, keys)
         for n_s, n in event.events([sub_space, self], sub_space.nodes):
-            n_s.left = coerce(n.left)
-            n_s.right = coerce(n.right)
-            n_s.past = coerce(n.past)
-            n_s.future = coerce(n.future)
-            n_s.faces = n.faces
+            event.connect_spatial(coerce(n.left), n_s)  # n_s.left = coerce(n.left)
+            event.connect_spatial(n_s, coerce(n.right))  # n_s.right = coerce(n.right)
+            event.connect_temporal(n_s, past=coerce(n.past))  # n_s.past = coerce(n.past)
+            event.connect_temporal(n_s, future=coerce(n.future))  # n_s.future = coerce(n.future)
+            event.set_faces(n_s, n.faces)
 
         # loop through all removed faces and remove their properties from self and add them to sub_space
         for f in sub_space.faces:
@@ -227,11 +234,11 @@ class SpaceTime(object):
             self.add_node(n)
 
         for n, n_s in event.events([self, sub_space], nodes):
-            n.left = n_s.left
-            n.right = n_s.right
-            n.past = n_s.past
-            n.future = n_s.future
-            n.faces = n_s.faces
+            event.connect_spatial(n_s.left, n)  # n.left = n_s.left
+            event.connect_spatial(n, n_s.right)  # n.right = n_s.right
+            event.connect_temporal(n, past=n_s.past)  # n.past = n_s.past
+            event.connect_temporal(n, future=n_s.future)  # n.future = n_s.future
+            event.set_faces(n, n_s.faces)
 
         for f in faces:
             self.faces.append(f)
@@ -252,7 +259,7 @@ class SpaceTime(object):
 
         # remove the sub_space that is going to be modified
         sub_space = self.pop([node])
-        future_s = Event(sub_space, future) # Need these two because they have been "popped" out of the original spacetime
+        future_s = Event(sub_space, future)  # Need these two because they have been "popped" out of the original spacetime
         past_s = Event(sub_space, past)
 
         # increment the total node counter
@@ -266,11 +273,9 @@ class SpaceTime(object):
         left = node_s.left
         right = node_s.right
 
-        # spatial changes.
-        node_s.left = new_s
-        new_s.right = node_s
-        new_s.left = left
-        left_s.right = new_s
+        # spatial changes
+        event.connect_spatial(new_s, node_s)  # new_s.right = node_s and node_s.left = new_s
+        event.connect_spatial(left_s, new_s)  # new_s.left = left_s and left_s.right = new_s
 
         # future changes
         # TODO examine algorithm concept of connection vs Spacetime (e.g. after popping a node out, what does asking for "left" mean?)
@@ -280,14 +285,14 @@ class SpaceTime(object):
         while f in node_s.future:
             if not f.is_gluing_point:
                 new_future_set.append(f)
-                sub_space.node_future[event.event_key(node)].remove(event.event_key(f)) # TODO cleanup the event key coercion by figuring out workaround for node.future.remove()
+                sub_space.node_future[event.event_key(node)].remove(event.event_key(f))  # TODO cleanup the event key coercion by figuring out workaround for node.future.remove()
                 sub_space.node_past[event.event_key(f)].remove(event.event_key(node))
             f = f.left
-        new_s.future = list(set(new_future_set))
+        event.connect_temporal(new_s, future=list(set(new_future_set)))
         old_future_set = list(
             set(node_s.future) - set(new_future_set)
         ) + [future_s]
-        node_s.future = old_future_set
+        event.connect_temporal(node_s, future=old_future_set)
         # sub_space.node_past[future].append(new_node)
 
         # past changes
@@ -300,9 +305,9 @@ class SpaceTime(object):
                 sub_space.node_future[event.event_key(p)].remove(event.event_key(node_s))
             p = p.left
 
-        new_s.past = new_past_set
+        event.connect_temporal(new_s, past=new_past_set)
         old_past_set = list(set(node_s.past) - set(new_past_set)) + [past_s]
-        node_s.past = old_past_set
+        event.connect_temporal(node_s, past=old_past_set)
         # sub_space.node_future[past].append(new_node)
 
         # face changes
@@ -364,8 +369,8 @@ class SpaceTime(object):
         sub_space.faces.append(frozenset({left.key, new_s.key, leftmost_past.key}))
         sub_space.face_dilaton[frozenset({left.key, new_s.key, leftmost_past.key})] = -1
 
-        new_s.faces = []
-        node_s.faces = []
+        event.set_faces(new_s, [])
+        event.set_faces(node_s, [])
         self.push(sub_space)
 
     def imove(self, node):

--- a/cdtea/tests/test_event.py
+++ b/cdtea/tests/test_event.py
@@ -34,6 +34,7 @@ class TestEvent:
         assert repr(e) == 'Event(ST2, 1)'
 
     def test_event_pass_thru_getattr(self):
+        """Test event getattr behavior for passthru attributes"""
         dst = test_space_time.dummy_space_time(2, 2)
         e0, e1, e2, e3 = event.events(dst, range(4))
         assert e0.right == e1
@@ -42,22 +43,61 @@ class TestEvent:
         assert e3.past == [e0, e1]
 
     def test_event_safe_getattr(self):
+        """Test event getattr behavior for non passthru attributes"""
         dst = test_space_time.dummy_space_time()
         e0 = event.Event(space_time=dst, event_key=0)
         assert isinstance(e0.space_time, SpaceTime)
         assert isinstance(e0.key, int)
 
     def test_event_pass_thru_setattr(self):
+        """Test event setattr behavior for passthru attributes"""
         dst = test_space_time.dummy_space_time(2, 2)
         e0, e1, e2, e3 = event.events(dst, range(4))
         e0.right = e2  # this doesn't make physical sense, but we're testing interface
         assert dst.node_right[0] == 2  # verify that the setattr updated the underlying SpaceTime instance
 
     def test_event_safe_setattr(self):
+        """Test event setattr behavior for non passthru attributes"""
         dst = test_space_time.dummy_space_time(2, 2)
         e0, e1, e2, e3 = event.events(dst, range(4))
         e0.key = -1  # this doesn't make physical sense, but we're testing interface
         assert dst.node_right[0] == 1  # verify that the setattr DID NOT update the underlying SpaceTime instance TODO check more attrs / eq
+
+    def test_event_hash(self):
+        """Test Event Hash"""
+        dst_1 = test_space_time.dummy_space_time(2, 2)
+        e0_1, *_ = event.events(dst_1, range(4))
+
+        dst_2 = test_space_time.dummy_space_time(2, 2)
+        e0_2, *_ = event.events(dst_2, range(4))
+
+        assert hash(e0_1) == hash(e0_2)
+
+    def test_spatial_neighbors(self):
+        """Test spatial neighbors"""
+        dst = test_space_time.dummy_space_time(3, 3)
+        e0, e1, e2, e3, e4, e5, e6, e7, e8 = event.events(dst, range(9))
+        assert e0.spatial_neighbors == [e2, e1]
+
+    def test_temporal_neighbors(self):
+        """Test temporal neighbors"""
+        dst = test_space_time.dummy_space_time(3, 3)
+        e0, e1, e2, e3, e4, e5, e6, e7, e8 = event.events(dst, range(9))
+        assert e0.temporal_neighbors == [e8, e6, e3, e4]
+
+    def test_neighbors(self):
+        """Test neighbors"""
+        dst = test_space_time.dummy_space_time(3, 3)
+        e0, e1, e2, e3, e4, e5, e6, e7, e8 = event.events(dst, range(9))
+        assert e0.neighbors == [e2, e1, e8, e6, e3, e4]
+
+    def test_is_gluing_point(self):
+        """Test is gluing point"""
+        dst = test_space_time.dummy_space_time(2, 2)
+        e1 = event.Event(dst, event.GluingPoint(0))
+        e2 = event.Event(dst, 0)
+        assert e1.is_gluing_point
+        assert not e2.is_gluing_point
 
 
 class TestEventUtilities:
@@ -76,3 +116,25 @@ class TestEventUtilities:
         e0, e1 = event.events(dst, [0, 1])
         assert isinstance(e0, event.Event)
         assert isinstance(e1, event.Event)
+
+
+class TestGluingPoint:
+    """Test gluing point utilities"""
+
+    def test_gluing_point_class(self):
+        """Test gluing point class"""
+        i = 1
+        g = event.GluingPoint(1)
+        assert g == i
+        assert g in [1]
+
+    def test_coerce_gluing_point(self):
+        """Test gluing point coercion"""
+        dst_1 = test_space_time.dummy_space_time(2, 2)
+        e0_1 = event.Event(dst_1, 0)
+        dst_2 = dst_1.pop([e0_1])
+        e0_2 = event.Event(dst_2, 0)
+        e0_star = event.coerce_gluing_point(dst_1, e0_2)
+        assert not isinstance(e0_1.key, event.GluingPoint)
+        assert not isinstance(e0_2.key, event.GluingPoint)
+        assert isinstance(e0_star.key, event.GluingPoint)

--- a/cdtea/tests/test_event.py
+++ b/cdtea/tests/test_event.py
@@ -100,6 +100,52 @@ class TestEvent:
         assert not e2.is_gluing_point
 
 
+class TestEdgeConsistency:
+    """Test Edge Consistency Rules"""
+
+    def test_consistent_set_left(self):
+        """Check set .left"""
+        dst = test_space_time.dummy_space_time(3, 3)
+        e0, e1, e2, e3, e4, e5, e6, e7, e8 = event.events(dst, range(9))
+
+        assert e0.right == e1
+        e0.right = e2  # this doesn't make physical sense, but we're testing interface
+        assert e2.left == e0
+        # assert e1.left is None
+
+    def test_consistent_set_right(self):
+        """Check set .right"""
+        dst = test_space_time.dummy_space_time(3, 3)
+        e0, e1, e2, e3, e4, e5, e6, e7, e8 = event.events(dst, range(9))
+
+        assert e0.left == e2
+        e0.left = e1
+        assert e1.right == e0
+        # assert e8.left is None
+
+    def test_consistent_set_past(self):
+        """Check set .past"""
+        dst = test_space_time.dummy_space_time(3, 3)
+        e0, e1, e2, e3, e4, e5, e6, e7, e8 = event.events(dst, range(9))
+
+        assert e0.past == [e8, e6]
+        e0.past = [e8, e7]
+        assert e0 in e7.future
+        assert e0 in e8.future
+        # assert e0 not in e6.future
+
+    def test_consistent_set_future(self):
+        """Check set .future"""
+        dst = test_space_time.dummy_space_time(3, 3)
+        e0, e1, e2, e3, e4, e5, e6, e7, e8 = event.events(dst, range(9))
+
+        assert e0.future == [e3, e4]
+        e0.future = [e4, e5]
+        assert e0 in e4.past
+        assert e0 in e5.past
+        # assert e0 not in e4.past
+
+
 class TestEventUtilities:
     """Test utility functions in event module"""
 

--- a/cdtea/tests/test_package.py
+++ b/cdtea/tests/test_package.py
@@ -1,0 +1,12 @@
+"""Add Tests for Package-Level Features"""
+
+import cdtea
+
+
+class TestPackage:
+    """Tests for CDTea package"""
+
+    def test_version(self):
+        """Test package version, prevents accidental bumps"""
+        assert cdtea.__VERSION__ == (0, 0, 1)
+        assert cdtea.__version__ == '0.0.1'

--- a/cdtea/tests/test_space_time.py
+++ b/cdtea/tests/test_space_time.py
@@ -1,5 +1,5 @@
 """Unittests for SpaceTime"""
-
+from cdtea import event
 from cdtea.space_time import SpaceTime
 
 
@@ -11,11 +11,34 @@ def dummy_space_time(spatial_size: int = 2, temporal_size: int = 1):
 
 
 class TestSpaceTime:
+    """Test SpaceTime classes"""
+
     def test_dummy_space_time(self):
         """Coverage ftw"""
         dst = dummy_space_time()
         assert isinstance(dst, SpaceTime)
         assert len(dst.nodes) == 2
+
+    def test_pop(self):
+        dst = dummy_space_time(3, 3)
+        e0 = event.Event(dst, 0)
+        dst2 = dst.pop([e0])
+        assert isinstance(dst2, SpaceTime)
+
+    def test_push(self):
+        dst = dummy_space_time(3, 3)
+        e0 = event.Event(dst, 0)
+        dst2 = dst.pop([e0])
+        dst.push(dst2)
+        # TODO add real equivalence check
+        assert isinstance(dst, SpaceTime)
+
+    def test_move(self):
+        dst = dummy_space_time(3, 3)
+        n, f, p = event.events(dst, [4, 7, 1])
+        dst.move(n, f, p)
+        assert isinstance(dst, SpaceTime)
+
 
 # Original Testing Code Below (commented out until migrated into unittests)
 # this checks if in a flat space-time each node belongs to 6 simplices


### PR DESCRIPTION
# Description

When an edge is implicitly modified via `setattr` on an `Event` instance that is one of the vertices of the edge, the other `Event` instance will be modified to preserve the following consistency conditions, where `A`, `B` are two events:

1. `A.left == B` <--> `A == B.right`
1. `A.right == B` <--> `A == B.left`
1. `B in A.past` <--> `A in B.future`
1. `B in A.future` <--> `A in B.past`

Fixes #17 

Changes:
- Added more tests to various event utilities
- Added edge consistency code inside `Event.__setattr__`
- Added some basic tests for `SpaceTime` methods

# Testing

- [x] PR Test Suite
- [x] Ran `run.py` manually

# Examples
## Edge Consistency 
```python
>>> dst = test_space_time.dummy_space_time(3, 3)
>>> e0, e1, e2 = event.events(dst, range(3))
>>> e0.right
Event(ST9, 2) # e2
>>> e0.right = e2  
>>> e2.left
Event(ST9, 0) # e0
```

## Problem: What to do with replaced events?
What to do with original events that get replaced by new events? For example, given events `A, B, C` where `A.left == B`, if we set `A.left = C`, then we will observe `C.right == A` as expected. However, it is still true that `B.right = A`, which is a violation of the edge consistency conditions. What should `B.right` be set to? It could be set to `None` as a sentinel value indicating the lack of an edge.

