### PR TITLE
Make SpaceTime Serializable

### DIFF
--- a/cdtea/modifications.py
+++ b/cdtea/modifications.py
@@ -16,7 +16,7 @@ def move(st, node, future, past):
     past_s = event.Event(sub_space, past)
 
     # increment the total node counter
-    new_node_num = max(st.nodes + sub_space.nodes) + 1
+    new_node_num = max(st.nodes.union(sub_space.nodes)) + 1
     sub_space.add_node(new_node_num)
 
     # create a node object for easy manipulation. This also automatically adds the node to the sub_space

--- a/cdtea/space_time.py
+++ b/cdtea/space_time.py
@@ -1,7 +1,8 @@
 """
 Trying to use node and face NOT vertex and simplex
 """
-
+import pathlib
+import pickle
 import random
 import typing
 from cdtea import event
@@ -218,6 +219,23 @@ class SpaceTime(object):
             'dead_references': self.dead_references,
         }
 
+    def to_pickle(self, path: typing.Union[str, pathlib.Path] = None):
+        """Convert SpaceTime to pickle format
+
+        Args:
+            path:
+                str or Path, default None. If specified write out the pickle to this location
+
+        Returns:
+            bytes, if output_path is None
+        """
+        if path is None:
+            return pickle.dumps(self)
+
+        path = path if isinstance(path, pathlib.Path) else pathlib.Path(path)
+        with open(path.as_posix(), 'wb') as fid:
+            pickle.dump(self, file=fid)
+
     @staticmethod
     def from_dict(config_dict: dict):
         """Create a SpaceTime object from a configuration dict
@@ -234,6 +252,29 @@ class SpaceTime(object):
             if key not in config_dict:
                 raise SerializationError('Missing key {} when attempting to create SpaceTime from dict:\n{}'.format(key, str(config_dict)))
         return SpaceTime(**config_dict)  # pass-thru to init method
+
+    @staticmethod
+    def from_pickle(data: bytes = None, path: typing.Union[str, pathlib.Path] = None):
+        """Create a SpaceTime object from a pickle string or file
+
+        Args:
+            data:
+                str, default None. If specified use this pickle string
+            path:
+                str or Path, default None. If specified use this full path
+
+        Returns:
+            SpaceTime
+        """
+        if (data is None and path is None) or (data is not None and path is not None):
+            raise SerializationError('Must specify only one of source and path when loading SpaceTime from pickle')
+
+        if data is not None:
+            return pickle.loads(data)
+
+        path = path if isinstance(path, pathlib.Path) else pathlib.path(path)
+        with open(path.as_posix(), 'rb') as fid:
+            return pickle.load(fid)
 
 
 def generate_flat_spacetime(space_size: int, time_size: int):

--- a/cdtea/space_time.py
+++ b/cdtea/space_time.py
@@ -9,30 +9,33 @@ from cdtea.event import Event
 
 
 class SpaceTime(object):
-    """docstring for SpaceTime."""
+    """SpaceTime represents a collection of linked events. The structure of those
+    links, both spacelike and timelike, determines the geometry of the piecewise
+    linear manifold represented by the SpaceTime.
+    """
 
-    # __slots__ = []
-
-    def __init__(self, closed: bool = True):
+    def __init__(self, nodes: set = None, node_left: dict = None, node_right: dict = None,
+                 node_past: dict = None, node_future: dict = None, faces_containing: dict = None,
+                 faces: set = None, face_dilation: dict = None, face_x: dict = None,
+                 face_t: dict = None, dead_references: set = None, closed: bool = True):
         super(SpaceTime, self).__init__()
         self.closed = closed
 
         # consider adding curvature here aswell
-        self.nodes = []  # nodes is just a list of indicies
-        self.node_left = {}  # a dict with node indices as keys
-        self.node_right = {}  # a dict with node indices as keys
-        self.node_past = {}  # a dict with node indices as keys
-        self.node_future = {}  # a dict with node indices as keys
-        self.faces_containing = {}
+        self.nodes = set() if nodes is None else nodes  # nodes is just a list of indicies
+        self.node_left = {} if node_left is None else node_left  # a dict with node indices as keys
+        self.node_right = {} if node_right is None else node_right  # a dict with node indices as keys
+        self.node_past = {} if node_past is None else node_past  # a dict with node indices as keys
+        self.node_future = {} if node_future is None else node_future  # a dict with node indices as keys
+        self.faces_containing = {} if faces_containing is None else faces_containing
 
-        self.faces = []  # faces is a frozenset of node indices
-        self.face_dilaton = {}  # a dict with keys of face tuples and field vals
-        self.face_x = {}  # a dict with keys of face tuples space-like connected
-        self.face_t = {}  # a dict with keys of face tuples time-like connected
+        self.faces = set() if faces is None else faces  # faces is a frozenset of node indices
+        self.face_dilaton = {} if face_dilation is None else face_dilation # a dict with keys of face tuples and field vals
+        self.face_x = {} if face_x is None else face_x  # a dict with keys of face tuples space-like connected
+        self.face_t = {} if face_t is None else face_t # a dict with keys of face tuples time-like connected
 
         # This could be modified to include a list of dead references
-        self.dead_references = []
-
+        self.dead_references = set() if dead_references is None else dead_references
 
     def __eq__(self, other):
         """Equivalence between """
@@ -45,13 +48,17 @@ class SpaceTime(object):
     def max_node(self):
         return max(self.nodes)
 
+    @property
+    def ordered_nodes(self) -> list:
+        return list(sorted(self.nodes))
+
     def get_random_node(self):
         return event.Event(self, random.choice(self.nodes))
 
     def get_layers(self, n=False):
         """returns a list of lists where each list contains all nodes in a specific layer, contains all nodes """
         if not n:
-            n = self.nodes[0]
+            n = self.ordered_nodes[0]
         used = []
         layers = []
         layer = []
@@ -72,7 +79,7 @@ class SpaceTime(object):
         else:
             if n in self.nodes:
                 raise ValueError('Cannot add node {:d} to spacetime {}, already exists'.format(n, self))
-        self.nodes.append(n)
+        self.nodes.add(n)
         self.node_left[n] = None
         self.node_right[n] = None
         self.node_future[n] = []
@@ -111,12 +118,12 @@ class SpaceTime(object):
         # removes duplicates
         faces = list(set(faces))
         nodes = list(set(nodes))
-        self.dead_references = nodes.copy()  # i.e these nodes are no longer in the st
+        self.dead_references = set(nodes.copy())  # i.e these nodes are no longer in the st
 
         # set the sub_space nodes and faces
         for n in nodes:
             sub_space.add_node(n=event.event_key(n))
-        sub_space.faces = faces.copy()
+        sub_space.faces = set(faces.copy())
 
         # loop through all removed nodes and remove their properties from self and add them to sub_space
         # taking care to label gluing points (references to nodes that do not belong to sub_space)
@@ -158,7 +165,7 @@ class SpaceTime(object):
             # raise ValueError()
 
         # add a check to make sure that we are inserting unique new nodes
-        nodes = sub_space.nodes
+        nodes = sub_space.ordered_nodes
         faces = sub_space.faces
 
         for n in nodes:
@@ -172,7 +179,7 @@ class SpaceTime(object):
             event.set_faces(n, n_s.faces)
 
         for f in faces:
-            self.faces.append(f)
+            self.faces.add(f)
 
         for f in sub_space.faces:
             self.face_dilaton[f] = sub_space.face_dilaton[f]
@@ -193,7 +200,7 @@ def generate_flat_spacetime(space_size: int, time_size: int):
     for t in range(time_size):
         start = index  # the first index in the current time slice
         for x in range(space_size):
-            spacetime.nodes.append(index)
+            spacetime.add_node(index)
 
             left = start + (index - 1) % space_size
             right = start + (index + 1) % space_size
@@ -221,8 +228,8 @@ def generate_flat_spacetime(space_size: int, time_size: int):
             f1 = frozenset({index, right, future_right})
             f2 = frozenset({index, left, past_left})
 
-            spacetime.faces.append(f1)
-            spacetime.faces.append(f2)
+            spacetime.faces.add(f1)
+            spacetime.faces.add(f2)
 
             # This is where we chose the initial dilaton values for each simplex
             spacetime.face_dilaton[f1] = 1

--- a/cdtea/space_time.py
+++ b/cdtea/space_time.py
@@ -246,8 +246,19 @@ class SpaceTime(object):
         Returns:
             networkx.Graph
         """
-        G = networkx.Graph()
+        # Construct initial graph
+        layers = self.get_layers()
+        G = networkx.Graph(num_layers=len(layers))
         G.add_nodes_from(self.ordered_nodes)
+
+        # Add information about node layers
+        layers_dict = {}
+        for n, layer in enumerate(layers):
+            for node in layer:
+                layers_dict[node] = {'layer': n}
+        networkx.set_node_attributes(G, layers_dict)
+
+        # Add information about edge types
         edge_types = {}
         for n in self.ordered_nodes:
             for s in (self.node_left[n], self.node_right[n]):

--- a/cdtea/tests/test_space_time.py
+++ b/cdtea/tests/test_space_time.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import tempfile
 
+import networkx
 import pytest
 
 from cdtea import event, modifications, space_time
@@ -131,3 +132,9 @@ class TestSpaceTimeSerialize:
             st_loaded = SpaceTime.from_pickle(path=path)
             assert isinstance(st_loaded, SpaceTime)
             assert st_loaded == st
+
+    def test_to_networkx(self):
+        """Test conversion to networkx"""
+        st = dummy_space_time(2, 2)
+        G = st.to_networkx()
+        assert isinstance(G, networkx.Graph)

--- a/cdtea/tests/test_space_time.py
+++ b/cdtea/tests/test_space_time.py
@@ -1,4 +1,8 @@
 """Unittests for SpaceTime"""
+import os
+import pathlib
+import tempfile
+
 import pytest
 
 from cdtea import event, modifications, space_time
@@ -67,6 +71,18 @@ class TestSpaceTimeSerialize:
                           'node_right': {0: 1, 1: 0, 2: 3, 3: 2},
                           'nodes': {0, 1, 2, 3}}
 
+    SAMPLE_CONFIG_PICKLE = (b'\x80\x04\x95\xc7\x02\x00\x00\x00\x00\x00\x00\x8c\x10cdtea.space_time\x94\x8c\tSpaceTime\x94\x93\x94)\x81\x94}\x94(\x8c\x06closed\x94\x88'
+                            b'\x8c\x05nodes\x94\x8f\x94(K\x00K\x01K\x02K\x03\x90\x8c\tnode_left\x94}\x94(K\x00K\x01K\x01K\x00K\x02K\x03K\x03K\x02u\x8c\nnode_right\x94}\x94(K\x00K\x01'
+                            b'K\x01K\x00K\x02K\x03K\x03K\x02u\x8c\tnode_past\x94}\x94(K\x00]\x94(K\x03K\x02eK\x01]\x94(K\x02K\x03eK\x02]\x94(K\x01K\x00eK\x03]\x94(K\x00K\x01e'
+                            b'u\x8c\x0bnode_future\x94}\x94(K\x00]\x94(K\x02K\x03eK\x01]\x94(K\x03K\x02eK\x02]\x94(K\x00K\x01eK\x03]\x94(K\x01K\x00eu\x8c\x10faces_containin'
+                            b'g\x94}\x94(K\x00]\x94((K\x00K\x01K\x03\x91\x94(K\x00K\x01K\x03\x91\x94(K\x00K\x02K\x03\x91\x94(K\x00K\x02K\x03\x91\x94(K\x00K\x01K\x02\x91\x94('
+                            b'K\x00K\x01K\x02\x91\x94eK\x01]\x94((K\x00K\x01K\x02\x91\x94(K\x00K\x01K\x02\x91\x94(K\x01K\x02K\x03\x91\x94(K\x01K\x02K\x03\x91\x94(K\x00K\x01K'
+                            b'\x03\x91\x94(K\x00K\x01K\x03\x91\x94eK\x02]\x94((K\x01K\x02K\x03\x91\x94(K\x01K\x02K\x03\x91\x94(K\x00K\x01K\x02\x91\x94(K\x00K\x01K\x02\x91\x94(K'
+                            b'\x00K\x02K\x03\x91\x94(K\x00K\x02K\x03\x91\x94eK\x03]\x94((K\x00K\x02K\x03\x91\x94(K\x00K\x02K\x03\x91\x94(K\x00K\x01K\x03\x91\x94(K\x00K\x01K\x03'
+                            b'\x91\x94(K\x01K\x02K\x03\x91\x94(K\x01K\x02K\x03\x91\x94eu\x8c\x05faces\x94\x8f\x94(h)h\x1bh0h"\x90\x8c\x0cface_dilaton\x94}\x94(h\x1bJ\xff'
+                            b'\xff\xff\xffh"J\xff\xff\xff\xffh)J\xff\xff\xff\xffh0J\xff\xff\xff\xffu\x8c\x06face_x\x94}\x94(h\x1b]\x94(h\x1e(K\x01K\x02K\x03\x91\x94eh"]\x94(h'
+                            b'%(K\x00K\x02K\x03\x91\x94eh)]\x94(h,(K\x00K\x01K\x03\x91\x94eh0]\x94(h3(K\x00K\x01K\x02\x91\x94eu\x8c\x06face_t\x94}\x94(h\x1bh h"h\'h)h.h0h5u\x8c\x0fdead_references\x94\x8f\x94ub.')
+
     def test_to_dict(self):
         """Test serialization to dict"""
         st = dummy_space_time(2, 2)
@@ -85,3 +101,33 @@ class TestSpaceTimeSerialize:
         incomplete_dict.pop('nodes')
         with pytest.raises(space_time.SerializationError):
             SpaceTime.from_dict(incomplete_dict)
+
+    def test_to_pickle(self):
+        """Test conversion of SpaceTime to pickle data"""
+        st = dummy_space_time(2, 2)
+        st_s = st.to_pickle()
+        assert st_s == self.SAMPLE_CONFIG_PICKLE
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / 'test_to_pickle.pkl'
+            st.to_pickle(path=path)
+            assert os.path.exists(path.as_posix())  # check file written out
+
+            with open(path.as_posix(), 'rb') as fid:
+                content = fid.read()
+                assert content == self.SAMPLE_CONFIG_PICKLE
+
+    def test_from_pickle(self):
+        """Test creation of SpaceTime from pickle"""
+        st = dummy_space_time(2, 2)
+        st_loaded = SpaceTime.from_pickle(data=self.SAMPLE_CONFIG_PICKLE)
+        assert isinstance(st_loaded, SpaceTime)
+        assert st_loaded == st
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / 'test_to_pickle.pkl'
+            with open(path.as_posix(), 'wb') as fid:
+                fid.write(self.SAMPLE_CONFIG_PICKLE)
+            st_loaded = SpaceTime.from_pickle(path=path)
+            assert isinstance(st_loaded, SpaceTime)
+            assert st_loaded == st

--- a/cdtea/tests/test_space_time.py
+++ b/cdtea/tests/test_space_time.py
@@ -1,5 +1,7 @@
 """Unittests for SpaceTime"""
-from cdtea import event, modifications
+import pytest
+
+from cdtea import event, modifications, space_time
 from cdtea.space_time import SpaceTime
 from cdtea.space_time import generate_flat_spacetime
 
@@ -33,24 +35,53 @@ class TestSpaceTime:
         # TODO add real equivalence check
         assert isinstance(dst, SpaceTime)
 
+    def test_equality(self):
+        """Test equality"""
+        dst = dummy_space_time(3, 3)
+        dst_2 = dummy_space_time(3, 3)
+        assert dst == dst_2
 
-# Original Testing Code Below (commented out until migrated into unittests)
-# this checks if in a flat space-time each node belongs to 6 simplices
-# def is_flat(st):
-#     for n in st.nodes:
-#         if not (st.get_faces_containing(n) == st.faces_containing[n]):
-#             return False
-#     return True
-#
-#
-# def is_valid_move(st, node, past, future):
-#     pass
-#
-#
-# # make sure there no duplicate faces or nodes
-#
-#
-# def push_pop(st, node):
-#     sub_space = st.pop(node)
-#     st.push(sub_space)
-#     # Check that this is the same as when starting
+        e4 = event.Event(dst, 4)
+        sub_dst = dst.pop([e4])
+        assert dst != dst_2
+
+
+class TestSpaceTimeSerialize:
+    """Serialization tests for spacetime class"""
+
+    SAMPLE_CONFIG_DICT = {'closed': True, 'dead_references': set(),
+                          'face_dilation': {frozenset({0, 1, 3}): -1, frozenset({0, 1, 2}): -1, frozenset({1, 2, 3}): -1, frozenset({0, 2, 3}): -1},
+                          'face_t': {frozenset({0, 1, 3}): frozenset({0, 1, 2}), frozenset({0, 1, 2}): frozenset({0, 1, 3}), frozenset({1, 2, 3}): frozenset({0, 2, 3}),
+                                     frozenset({0, 2, 3}): frozenset({1, 2, 3})},
+                          'face_x': {frozenset({0, 1, 3}): [frozenset({0, 2, 3}), frozenset({1, 2, 3})], frozenset({0, 1, 2}): [frozenset({1, 2, 3}), frozenset({0, 2, 3})],
+                                     frozenset({1, 2, 3}): [frozenset({0, 1, 2}), frozenset({0, 1, 3})], frozenset({0, 2, 3}): [frozenset({0, 1, 3}), frozenset({0, 1, 2})]},
+                          'faces': {frozenset({1, 2, 3}), frozenset({0, 1, 3}), frozenset({0, 2, 3}), frozenset({0, 1, 2})},
+                          'faces_containing': {
+                              0: [frozenset({0, 1, 3}), frozenset({0, 1, 3}), frozenset({0, 2, 3}), frozenset({0, 2, 3}), frozenset({0, 1, 2}), frozenset({0, 1, 2})],
+                              1: [frozenset({0, 1, 2}), frozenset({0, 1, 2}), frozenset({1, 2, 3}), frozenset({1, 2, 3}), frozenset({0, 1, 3}), frozenset({0, 1, 3})],
+                              2: [frozenset({1, 2, 3}), frozenset({1, 2, 3}), frozenset({0, 1, 2}), frozenset({0, 1, 2}), frozenset({0, 2, 3}), frozenset({0, 2, 3})],
+                              3: [frozenset({0, 2, 3}), frozenset({0, 2, 3}), frozenset({0, 1, 3}), frozenset({0, 1, 3}), frozenset({1, 2, 3}), frozenset({1, 2, 3})]},
+                          'node_future': {0: [2, 3], 1: [3, 2], 2: [0, 1], 3: [1, 0]},
+                          'node_left': {0: 1, 1: 0, 2: 3, 3: 2},
+                          'node_past': {0: [3, 2], 1: [2, 3], 2: [1, 0], 3: [0, 1]},
+                          'node_right': {0: 1, 1: 0, 2: 3, 3: 2},
+                          'nodes': {0, 1, 2, 3}}
+
+    def test_to_dict(self):
+        """Test serialization to dict"""
+        st = dummy_space_time(2, 2)
+        config_dict = st.to_dict()
+        assert config_dict == self.SAMPLE_CONFIG_DICT
+
+    def test_from_dict(self):
+        """Load SpaceTime from dictionary"""
+        st_loaded = SpaceTime.from_dict(config_dict=self.SAMPLE_CONFIG_DICT)
+        st = dummy_space_time(2, 2)
+        assert isinstance(st_loaded, SpaceTime)
+        assert st_loaded == st
+
+        # Test incomplete dict raises error
+        incomplete_dict = self.SAMPLE_CONFIG_DICT.copy()
+        incomplete_dict.pop('nodes')
+        with pytest.raises(space_time.SerializationError):
+            SpaceTime.from_dict(incomplete_dict)

--- a/cdtea/visualization/tests/test_plot_st.py
+++ b/cdtea/visualization/tests/test_plot_st.py
@@ -1,0 +1,11 @@
+from cdtea import space_time
+from cdtea.visualization import plot_st
+
+
+class TestPlot:
+    """Test Plotting"""
+
+    def test_plot_3d_nx(self):
+        """Test Plot 3D NX"""
+        st = space_time.generate_flat_spacetime(3, 3)
+        plot_st.plot_3d_nx(st, render=False)

--- a/environment.yml
+++ b/environment.yml
@@ -6,8 +6,10 @@ channels:
 
 dependencies:
   - coverage
-  - numpy
+  - graphviz
   - matplotlib
+  - networkx
+  - numpy
   - plotly
   - pytest
   - python=3.8

--- a/environment.yml
+++ b/environment.yml
@@ -6,10 +6,10 @@ channels:
 
 dependencies:
   - coverage
-  - graphviz
   - matplotlib
   - networkx
   - numpy
   - plotly
   - pytest
   - python=3.8
+  - scipy


### PR DESCRIPTION
# Description

Fixes #6 

Changes:
- Made `SpaceTime` class serializable to and from `dict` and `pickle`
- Added write-out option for `to_pickle` method for saving `SpaceTime` configurations
- Added tests for serializations
- Enhanced equality comparison between `SpaceTime` instances to compare all attributes, using the dict serialization

# Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] PR Test Suite

# Examples

## SpaceTime Equivalence
It is now possible to compare `SpaceTime` instances completely, for instance:
```python
>>> dst = generate_flat_spacetime(3, 3)
>>> dst_2 = dummy_space_time(3, 3)
>>> dst == dst_2
True

>>> e4 = event.Event(dst, 4)
>>> sub_dst = dst.pop([e4])
>>> dst != dst_2
False
```

## Serialize SpaceTime objects
### Export to dictionary
```python
>>> cdt = generate_flat_spacetime(2, 2)
>>> st.to_dict()
{'closed': True, 'dead_references': set(),
 'face_dilation': {frozenset({0, 1, 3}): -1, frozenset({0, 1, 2}): -1, frozenset({1, 2, 3}): -1, frozenset({0, 2, 3}): -1},
 'face_t': {frozenset({0, 1, 3}): frozenset({0, 1, 2}), frozenset({0, 1, 2}): frozenset({0, 1, 3}), frozenset({1, 2, 3}): frozenset({0, 2, 3}), frozenset({0, 2, 3}): frozenset({1, 2, 3})},
 'face_x': {frozenset({0, 1, 3}): [frozenset({0, 2, 3}), frozenset({1, 2, 3})], frozenset({0, 1, 2}): [frozenset({1, 2, 3}), frozenset({0, 2, 3})], frozenset({1, 2, 3}): [frozenset({0, 1, 2}), frozenset({0, 1, 3})], frozenset({0, 2, 3}): [frozenset({0, 1, 3}), frozenset({0, 1, 2})]},
 'faces': {frozenset({1, 2, 3}), frozenset({0, 1, 3}), frozenset({0, 2, 3}), frozenset({0, 1, 2})},
 'faces_containing': {
    0: [frozenset({0, 1, 3}), frozenset({0, 1, 3}), frozenset({0, 2, 3}), frozenset({0, 2, 3}), frozenset({0, 1, 2}), frozenset({0, 1, 2})],
    1: [frozenset({0, 1, 2}), frozenset({0, 1, 2}), frozenset({1, 2, 3}), frozenset({1, 2, 3}), frozenset({0, 1, 3}), frozenset({0, 1, 3})],
    2: [frozenset({1, 2, 3}), frozenset({1, 2, 3}), frozenset({0, 1, 2}), frozenset({0, 1, 2}), frozenset({0, 2, 3}), frozenset({0, 2, 3})],
    3: [frozenset({0, 2, 3}), frozenset({0, 2, 3}), frozenset({0, 1, 3}), frozenset({0, 1, 3}), frozenset({1, 2, 3}), frozenset({1, 2, 3})]},
 'node_future': {0: [2, 3], 1: [3, 2], 2: [0, 1], 3: [1, 0]},
 'node_left': {0: 1, 1: 0, 2: 3, 3: 2},
 'node_past': {0: [3, 2], 1: [2, 3], 2: [1, 0], 3: [0, 1]},
 'node_right': {0: 1, 1: 0, 2: 3, 3: 2},
 'nodes': {0, 1, 2, 3}}
```

### Export To and Import From Pickle
```python
>>> cdt = generate_flat_spacetime(2, 2)
>>> cdt.to_pickle()[:20]
b'\x80\x04\x95\xc7\x02\x00\x00\x00\x00\x00\x00\x8c\x10cdtea.s'

# or output to file
>>> cdt.to_pickle(path='/path/to/output/file.pkl')

# or read in from file
>>> cdt.from_pickle(path='/path/to/output/file.pkl')
```

## Integration with `networkx`
Can convert `SpaceTime` instances into `networkx.Graph`
```python
>>> cdt = generate_flat_spacetime(2, 2)
>>> G = cdt.to_networkx()
<networkx.classes.graph.Graph at 0x7fc675bc8e80>

# Additional plotting utility using networkx layout algorithms
>>> plot_ts.plot_3d_nx(cdt)
```



